### PR TITLE
#3 - Different channels for different log levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ logging.AddSlack(options =>
      options.NotificationLevel = LogLevel.None;
      options.Environment = env.EnvironmentName;
      options.Channel = "#mychannel";
+     options.ChannelCritical = "#mychannel-critical";
      options.SanitizeOutputFunction = output => Regex.Replace(output, "@[^\\.@-]", "");
 });
             
@@ -51,6 +52,9 @@ logging.AddSlack(options =>
 
 `Channel`
 Overrides the channel or person that is configured in the Slack webhook.
+
+`ChannelCritical`, `ChannelError`, `ChannelWarning`, `ChannelInformation`, `ChannelDebug`, `ChannelTrace`
+Overrides the `Channel` setting for the specified log level. If any of these are unset, it will fall back to the `Channel` value.
 
 `LogLevel`
 Sets the minimum log level used. Defaults to `Warning`.

--- a/SlackLogger/SlackLoggerOptions.cs
+++ b/SlackLogger/SlackLoggerOptions.cs
@@ -8,6 +8,12 @@ namespace SlackLogger
     public class SlackLoggerOptions
     {
         public string Channel { get; set; }
+        public string ChannelCritical { get; set; }
+        public string ChannelError { get; set; }
+        public string ChannelWarning { get; set; }
+        public string ChannelInformation { get; set; }
+        public string ChannelDebug { get; set; }
+        public string ChannelTrace { get; set; }
         public string ApplicationName { get; set; }
         public string WebhookUrl { get; set; }
         public string EnvironmentName { get; set; }
@@ -36,6 +42,30 @@ namespace SlackLogger
                 if (configuration["Channel"] != null)
                 {
                     Channel = configuration["Channel"];
+                }
+                if (configuration["ChannelCritical"] != null)
+                {
+                    ChannelCritical = configuration["ChannelCritical"];
+                }
+                if (configuration["ChannelError"] != null)
+                {
+                    ChannelError = configuration["ChannelError"];
+                }
+                if (configuration["ChannelWarning"] != null)
+                {
+                    ChannelWarning = configuration["ChannelWarning"];
+                }
+                if (configuration["ChannelInformation"] != null)
+                {
+                    ChannelInformation = configuration["ChannelInformation"];
+                }
+                if (configuration["ChannelDebug"] != null)
+                {
+                    ChannelDebug = configuration["ChannelDebug"];
+                }
+                if (configuration["ChannelTrace"] != null)
+                {
+                    ChannelTrace = configuration["ChannelTrace"];
                 }
                 if (configuration["WebhookUrl"] != null)
                 {

--- a/SlackLogger/SlackService.cs
+++ b/SlackLogger/SlackService.cs
@@ -51,7 +51,7 @@ namespace SlackLogger
             {
                 var payload = new
                 {
-                    channel = _options.Channel,
+                    channel = GetChannel(logLevel),
                     username = "SlackLogger",
                     icon_emoji = icon,
                     text = $"{notification}*{_options.ApplicationName}* {environmentName}",
@@ -93,7 +93,25 @@ namespace SlackLogger
             }
         }
 
-
+        private string GetChannel(LogLevel logLevel)
+        {
+            switch (logLevel)
+            {
+                case LogLevel.Critical:
+                    return _options.ChannelCritical ?? _options.Channel;
+                case LogLevel.Error:
+                    return _options.ChannelError ?? _options.Channel;
+                case LogLevel.Warning:
+                    return _options.ChannelWarning ?? _options.Channel;
+                case LogLevel.Information:
+                    return _options.ChannelInformation ?? _options.Channel;
+                case LogLevel.Debug:
+                    return _options.ChannelDebug ?? _options.Channel;
+                case LogLevel.Trace:
+                    return _options.ChannelTrace ?? _options.Channel;
+                default: return "";
+            }
+        }
 
         private string GetIcon(LogLevel logLevel)
         {


### PR DESCRIPTION
This allows a user to specify a channel per log level if they wish. They can also specify the already existing "Channel" which is used as a fallback for anything that wasn't directly specified. This also allows any current setups to continue working without any changes.