### PR TITLE
Allow logger to be Optional

### DIFF
--- a/SlackLogger/Configuration.cs
+++ b/SlackLogger/Configuration.cs
@@ -13,6 +13,13 @@ namespace SlackLogger
             return builder;
         }
 
+        public static ILoggingBuilder AddSlack(this ILoggingBuilder builder, bool optional)
+        {
+            return builder.AddSlack(s =>
+            {
+                s.Optional = optional;
+            });
+        }
 
         public static ILoggingBuilder AddSlack(this ILoggingBuilder builder, Action<SlackLoggerOptions> configure)
         {

--- a/SlackLogger/SlackLoggerOptions.cs
+++ b/SlackLogger/SlackLoggerOptions.cs
@@ -32,6 +32,12 @@ namespace SlackLogger
             set => _notificationLevel = value;
         }
 
+        /// <summary>
+        /// If <see langword="true"/>, <see cref="LogLevel"/> will be forced to <see cref="LogLevel.None"/> given invalid options,
+        /// e.g. <see cref="WebhookUrl"/> is not set.
+        /// </summary>
+        public bool Optional { get; set; }
+
         public void Merge(IConfiguration configuration)
         {
             if (configuration != null)
@@ -112,6 +118,12 @@ namespace SlackLogger
         {
             if (string.IsNullOrWhiteSpace(WebhookUrl))
             {
+                if (Optional)
+                {
+                    LogLevel = LogLevel.None;
+                    return;
+                }
+
                 throw new ArgumentException("WebhookUrl must be set");
             }
             Uri uriResult;


### PR DESCRIPTION
Resolves #26 by forcing `LogLevel = None` if `WebhookUrl` is not set but `Optional` is `true`.